### PR TITLE
Add support to calico v3.22

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -1238,9 +1238,9 @@ downloads:
     url: "{{ calico_crds_download_url }}"
     unarchive: true
     unarchive_extra_opts:
-    - "--strip=6"
+    - "{{ '--strip=6' if (calico_version is version('v3.22.3','<')) else '--strip=3' }}"
     - "--wildcards"
-    - "*/_includes/charts/calico/crds/kdd/"
+    - "{{ '*/_includes/charts/calico/crds/kdd/' if (calico_version is version('v3.22.3','<')) else '*/libcalico-go/config/crd/' }}"
     owner: "root"
     mode: "0755"
     groups:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -131,7 +131,7 @@ kubeadm_download_url: "https://storage.googleapis.com/kubernetes-release/release
 etcd_download_url: "https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ image_arch }}.tar.gz"
 flannel_cni_download_url: "https://github.com/flannel-io/cni-plugin/releases/download/{{ flannel_cni_version }}/flannel-{{ image_arch }}"
 cni_download_url: "https://github.com/containernetworking/plugins/releases/download/{{ cni_version }}/cni-plugins-linux-{{ image_arch }}-{{ cni_version }}.tgz"
-calicoctl_download_url: "https://github.com/projectcalico/calicoctl/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
+calicoctl_download_url: "https://github.com/projectcalico/calico/releases/download/{{ calico_ctl_version }}/calicoctl-linux-{{ image_arch }}"
 calico_crds_download_url: "https://github.com/projectcalico/calico/archive/{{ calico_version }}.tar.gz"
 crictl_download_url: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ crictl_version }}/crictl-{{ crictl_version }}-{{ ansible_system | lower }}-{{ image_arch }}.tar.gz"
 helm_download_url: "https://get.helm.sh/helm-{{ helm_version }}-linux-{{ image_arch }}.tar.gz"
@@ -582,6 +582,9 @@ calicoctl_binary_checksums:
     v3.19.3: 0
     v3.18.6: 0
   amd64:
+    v3.22.5: ba75fa65be0e97555b37282e1ab469ad933866eed164b40513e835279bea7348
+    v3.22.3: a9e5f6bad4ad8c543f6bdcd21d3665cdd23edc780860d8e52a87881a7b3e203c
+    v3.22.0: 5138f6257308071df648cfb5d90201d17704d16767b8db807ed5fdec501559c9
     v3.21.2: d495edfc254e00f008ef6872422a31ef5f442a1ff96bcb724dd2df86ef75b7e3
     v3.20.3: 29bec97b1dfc135b830b0cbfd3dfe216f00e97e9e6ef08e620d81d4a09db6393
     v3.19.3: e9d91036764ec24f32025c3176efb2c2673b9936270e6165fb6583cce97bc43f
@@ -592,6 +595,9 @@ calicoctl_binary_checksums:
     v3.19.3: ec3cfbd2dccbd614ac353be8c9abf8e336d8700fbd2b9b76da1c3c4c14a6dfe2
     v3.18.6: 2990c2004d9b9ab6cfc913fe0ed521c12d7b5a3f3fcf4940549a8a15721e84dd
 calico_crds_archive_checksums:
+  v3.22.5: f3b6a6861b7beae549b4cf0be5c4b954c0cc19e95adb89dd9d78e983f9f2a5d7
+  v3.22.3: 55ece01da00f82c62619b82b6bfd6442a021acc6fd915a753735e6ebceabaa21
+  v3.22.0: 204c12a6394784861b38ad1951ef720f24dff53b5b8c56ced7b701257e4bba2b
   v3.21.2: 6f1342ac8b3d9ebfa9714f06aa92f4f0eea0d2b09d7e77ed73c0c9de0bb0aee8
   v3.20.3: 2a3a5cbe05c60fa2fc850252c4eecfa36dd6629191ed805eea31f9b5c740bc4c
   v3.19.3: 7066d0e6b0136920f82a75a5bd2d595e9f69bd3ab823403e920906569ec6be07

--- a/roles/network_plugin/calico/tasks/install.yml
+++ b/roles/network_plugin/calico/tasks/install.yml
@@ -126,10 +126,25 @@
     - enable_dual_stack_networks
 
 - block:
+    - name: Calico | Check if extra directory is needed
+      stat:
+        path: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds/{{ 'kdd' if (calico_version is version('v3.22.3','<')) else 'crd' }}"
+      register: kdd_path
+    - name: Calico | Set kdd path when calico < v3.22.3
+      set_fact:
+        calico_kdd_path: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds{{ '/kdd' if kdd_path.stat.exists is defined and kdd_path.stat.exists }}"
+      when:
+        - calico_version is version('v3.22.3', '<')
+    - name: Calico | Set kdd path when calico > v3.22.2
+      set_fact:
+        calico_kdd_path: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds{{ '/crd' if kdd_path.stat.exists is defined and kdd_path.stat.exists }}"
+      when:
+        - calico_version is version('v3.22.2', '>')
     - name: Calico | Create calico manifests for kdd
       assemble:
-        src: "{{ local_release_dir }}/calico-{{ calico_version }}-kdd-crds"
+        src: "{{ calico_kdd_path }}"
         dest: "{{ kube_config_dir }}/kdd-crds.yml"
+        mode: 0644
         delimiter: "---\n"
         regexp: ".*\\.yaml"
         remote_src: true

--- a/roles/upgrade/post-upgrade/tasks/main.yml
+++ b/roles/upgrade/post-upgrade/tasks/main.yml
@@ -11,11 +11,6 @@
     --timeout={{ upgrade_post_cilium_wait_timeout }}
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
 
-- name: Arbitrary wait time (20m)
-  ansible.builtin.pause:
-    minutes: 20
-  when: not ansible_check_mode
-
 - name: Uncordon node
   command: "{{ bin_dir }}/kubectl --kubeconfig {{ kube_config_dir }}/admin.conf uncordon {{ kube_override_hostname|default(inventory_hostname) }}"
   delegate_to: "{{ groups['kube_control_plane'][0] }}"


### PR DESCRIPTION
This PR adds support to calico v3.22. Before calico v3.22 they deprecated the old repo as you can see on the readme https://github.com/projectcalico/calicoctl

So I basically copied these code changes from the next release of kubespray (2.19) and added the parts relevant to support calico v3.22 and as extra support to 2 extra patches:
* v3.22.0 - Current version we have running in our clusters
* v3.22.5 - Lastest patch on that minor

Next release of kubespray only adds support to calico v3.22.3.