### PR TITLE
Backport containerd mirror config

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -6,10 +6,6 @@
   import_playbook: legacy_groups.yml
 
 - hosts: bastion[0]
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   environment: "{{ proxy_disable_env }}"
   roles:
@@ -17,10 +13,6 @@
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
 - hosts: k8s_cluster:etcd
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   strategy: linear
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   gather_facts: false
@@ -34,10 +26,6 @@
   import_playbook: facts.yml
 
 - hosts: k8s_cluster:etcd
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -48,10 +36,6 @@
     - { role: download, tags: download, when: "not skip_downloads" }
 
 - hosts: etcd
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -65,10 +49,6 @@
       when: not etcd_kubeadm_enabled| default(false)
 
 - hosts: k8s_cluster
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -82,10 +62,6 @@
       when: not etcd_kubeadm_enabled| default(false)
 
 - hosts: k8s_cluster
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -94,10 +70,6 @@
     - { role: kubernetes/node, tags: node }
 
 - hosts: kube_control_plane
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -108,10 +80,6 @@
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
 
 - hosts: k8s_cluster
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -122,10 +90,6 @@
     - { role: network_plugin, tags: network }
 
 - hosts: calico_rr
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -134,10 +98,6 @@
     - { role: network_plugin/calico/rr, tags: ['network', 'calico_rr'] }
 
 - hosts: kube_control_plane[0]
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -146,10 +106,6 @@
     - { role: win_nodes/kubernetes_patch, tags: ["master", "win_nodes"] }
 
 - hosts: kube_control_plane
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always  
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -163,10 +119,6 @@
     - { role: kubernetes-apps, tags: apps }
 
 - hosts: k8s_cluster
-  pre_tasks:
-  - include_vars:
-      dir: ../../vars/kubespray
-    tags: always  
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"

--- a/cluster.yml
+++ b/cluster.yml
@@ -6,6 +6,10 @@
   import_playbook: legacy_groups.yml
 
 - hosts: bastion[0]
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   environment: "{{ proxy_disable_env }}"
   roles:
@@ -13,6 +17,10 @@
     - { role: bastion-ssh-config, tags: ["localhost", "bastion"] }
 
 - hosts: k8s_cluster:etcd
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   strategy: linear
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   gather_facts: false
@@ -26,6 +34,10 @@
   import_playbook: facts.yml
 
 - hosts: k8s_cluster:etcd
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -36,6 +48,10 @@
     - { role: download, tags: download, when: "not skip_downloads" }
 
 - hosts: etcd
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -49,6 +65,10 @@
       when: not etcd_kubeadm_enabled| default(false)
 
 - hosts: k8s_cluster
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -62,6 +82,10 @@
       when: not etcd_kubeadm_enabled| default(false)
 
 - hosts: k8s_cluster
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -70,6 +94,10 @@
     - { role: kubernetes/node, tags: node }
 
 - hosts: kube_control_plane
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -80,6 +108,10 @@
     - { role: kubernetes-apps/cluster_roles, tags: cluster-roles }
 
 - hosts: k8s_cluster
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -90,6 +122,10 @@
     - { role: network_plugin, tags: network }
 
 - hosts: calico_rr
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -98,6 +134,10 @@
     - { role: network_plugin/calico/rr, tags: ['network', 'calico_rr'] }
 
 - hosts: kube_control_plane[0]
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -106,6 +146,10 @@
     - { role: win_nodes/kubernetes_patch, tags: ["master", "win_nodes"] }
 
 - hosts: kube_control_plane
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always  
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"
@@ -119,6 +163,10 @@
     - { role: kubernetes-apps, tags: apps }
 
 - hosts: k8s_cluster
+  pre_tasks:
+  - include_vars:
+      dir: ../../vars/kubespray
+    tags: always  
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   environment: "{{ proxy_disable_env }}"

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -2,6 +2,9 @@
 containerd_storage_dir: "/var/lib/containerd"
 containerd_state_dir: "/run/containerd"
 containerd_systemd_dir: "/etc/systemd/system/containerd.service.d"
+# The default value is not -999 here because containerd's oom_score_adj has been
+# set to the -999 even if containerd_oom_score is 0.
+# Ref: https://github.com/kubernetes-sigs/kubespray/pull/9275#issuecomment-1246499242
 containerd_oom_score: 0
 
 containerd_default_runtime: "runc"
@@ -12,6 +15,7 @@ containerd_runc_runtime:
   type: "io.containerd.runc.v2"
   engine: ""
   root: ""
+  base_runtime_spec: cri-base.json
   options:
     systemdCgroup: "{{ containerd_use_systemd_cgroup | ternary('true', 'false') }}"
 
@@ -21,6 +25,18 @@ containerd_additional_runtimes: []
 #    type: "io.containerd.kata.v2"
 #    engine: ""
 #    root: ""
+
+containerd_base_runtime_spec_rlimit_nofile: 65535
+
+containerd_default_base_runtime_spec_patch:
+  process:
+    rlimits:
+      - type: RLIMIT_NOFILE
+        hard: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
+        soft: "{{ containerd_base_runtime_spec_rlimit_nofile }}"
+
+containerd_base_runtime_specs:
+  cri-base.json: "{{ containerd_default_base_runtime_spec | combine(containerd_default_base_runtime_spec_patch, recursive=1) }}"
 
 containerd_grpc_max_recv_message_size: 16777216
 containerd_grpc_max_send_message_size: 16777216
@@ -34,7 +50,19 @@ containerd_metrics_grpc_histogram: false
 containerd_registries:
   "docker.io": "https://registry-1.docker.io"
 
+containerd_registries_mirrors:
+  - prefix: docker.io
+    mirrors:
+      - host: https://registry-1.docker.io
+        capabilities: ["pull", "resolve"]
+        skip_verify: false
+
 containerd_max_container_log_line_size: -1
+
+# If enabled it will allow non root users to use port numbers <1024
+containerd_enable_unprivileged_ports: false
+# If enabled it will allow non root users to use icmp sockets
+containerd_enable_unprivileged_icmp: false
 
 containerd_cfg_dir: /etc/containerd
 
@@ -46,3 +74,33 @@ containerd_registry_auth: []
 #  - registry: 10.0.0.2:5000
 #    username: user
 #    password: pass
+
+# Configure containerd service
+containerd_limit_proc_num: "infinity"
+containerd_limit_core: "infinity"
+containerd_limit_open_file_num: "infinity"
+containerd_limit_mem_lock: "infinity"
+
+# If enabled it will use config_path and config to be put in {{ containerd_cfg_dir }}/certs.d/
+containerd_use_config_path: false
+
+# OS distributions that already support containerd
+containerd_supported_distributions:
+  - "CentOS"
+  - "OracleLinux"
+  - "RedHat"
+  - "Ubuntu"
+  - "Debian"
+  - "Fedora"
+  - "AlmaLinux"
+  - "Rocky"
+  - "Amazon"
+  - "Flatcar"
+  - "Flatcar Container Linux by Kinvolk"
+  - "Suse"
+  - "openSUSE Leap"
+  - "openSUSE Tumbleweed"
+  - "Kylin Linux Advanced Server"
+  - "UnionTech"
+  - "UniontechOS"
+  - "openEuler"

--- a/roles/container-engine/containerd/defaults/main.yml
+++ b/roles/container-engine/containerd/defaults/main.yml
@@ -82,7 +82,7 @@ containerd_limit_open_file_num: "infinity"
 containerd_limit_mem_lock: "infinity"
 
 # If enabled it will use config_path and config to be put in {{ containerd_cfg_dir }}/certs.d/
-containerd_use_config_path: false
+containerd_use_config_path: true
 
 # OS distributions that already support containerd
 containerd_supported_distributions:

--- a/roles/container-engine/containerd/handlers/main.yml
+++ b/roles/container-engine/containerd/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart containerd
+- name: Restart containerd
   command: /bin/true
   notify:
     - Containerd | restart containerd

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -3,35 +3,35 @@
   fail:
     msg: "{{ ansible_distribution }} is not supported by containerd."
   when:
-    - ansible_distribution not in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Fedora", "AlmaLinux", "Rocky", "Amazon", "Flatcar", "Flatcar Container Linux by Kinvolk", "Suse", "openSUSE Leap", "openSUSE Tumbleweed", "Kylin Linux Advanced Server", "UnionTech", "openEuler"]
+    - not (allow_unsupported_distribution_setup | default(false)) and (ansible_distribution not in containerd_supported_distributions)
 
-- name: containerd | Remove any package manager controlled containerd package
+- name: Containerd | Remove any package manager controlled containerd package
   package:
     name: "{{ containerd_package }}"
     state: absent
   when:
     - not (is_ostree or (ansible_distribution == "Flatcar Container Linux by Kinvolk") or (ansible_distribution == "Flatcar"))
 
-- name: containerd | Remove containerd repository
+- name: Containerd | Remove containerd repository
   file:
     path: "{{ yum_repo_dir }}/containerd.repo"
     state: absent
   when:
     - ansible_os_family in ['RedHat']
 
-- name: containerd | Remove containerd repository
+- name: Containerd | Remove containerd repository
   apt_repository:
     repo: "{{ item }}"
     state: absent
   with_items: "{{ containerd_repo_info.repos }}"
   when: ansible_pkg_mgr == 'apt'
 
-- name: containerd | Download containerd
+- name: Containerd | Download containerd
   include_tasks: "../../../download/tasks/download_file.yml"
   vars:
     download: "{{ download_defaults | combine(downloads.containerd) }}"
 
-- name: containerd | Unpack containerd archive
+- name: Containerd | Unpack containerd archive
   unarchive:
     src: "{{ downloads.containerd.dest }}"
     dest: "{{ containerd_bin_dir }}"
@@ -39,9 +39,9 @@
     remote_src: yes
     extra_opts:
       - --strip-components=1
-  notify: restart containerd
+  notify: Restart containerd
 
-- name: containerd | Remove orphaned binary
+- name: Containerd | Remove orphaned binary
   file:
     path: "/usr/bin/{{ item }}"
     state: absent
@@ -56,14 +56,14 @@
     - containerd-shim-runc-v2
     - ctr
 
-- name: containerd | Generate systemd service for containerd
+- name: Containerd | Generate systemd service for containerd
   template:
     src: containerd.service.j2
     dest: /etc/systemd/system/containerd.service
     mode: 0644
-  notify: restart containerd
+  notify: Restart containerd
 
-- name: containerd | Ensure containerd directories exist
+- name: Containerd | Ensure containerd directories exist
   file:
     dest: "{{ item }}"
     state: directory
@@ -76,71 +76,64 @@
     - "{{ containerd_storage_dir }}"
     - "{{ containerd_state_dir }}"
 
-- name: containerd | Write containerd proxy drop-in
+- name: Containerd | Write containerd proxy drop-in
   template:
     src: http-proxy.conf.j2
     dest: "{{ containerd_systemd_dir }}/http-proxy.conf"
     mode: 0644
-  notify: restart containerd
+  notify: Restart containerd
   when: http_proxy is defined or https_proxy is defined
 
-- name: containerd | Generate default base_runtime_spec
+- name: Containerd | Generate default base_runtime_spec
   register: ctr_oci_spec
   command: "{{ containerd_bin_dir }}/ctr oci spec"
   check_mode: false
   changed_when: false
 
-- name: containerd | Store generated default base_runtime_spec
+- name: Containerd | Store generated default base_runtime_spec
   set_fact:
     containerd_default_base_runtime_spec: "{{ ctr_oci_spec.stdout | from_json }}"
 
-- name: containerd | Write base_runtime_specs
+- name: Containerd | Write base_runtime_specs
   copy:
     content: "{{ item.value }}"
     dest: "{{ containerd_cfg_dir }}/{{ item.key }}"
     owner: "root"
     mode: 0644
   with_dict: "{{ containerd_base_runtime_specs | default({}) }}"
-  notify: restart containerd
+  notify: Restart containerd
 
-- name: containerd | Copy containerd config file
+- name: Containerd | Copy containerd config file
   template:
     src: config.toml.j2
     dest: "{{ containerd_cfg_dir }}/config.toml"
     owner: "root"
     mode: 0640
-  notify: restart containerd
+  notify: Restart containerd
 
-- name: containerd ｜ Create registry directories
-  file:
-    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}"
-    state: directory
-    mode: 0755
-    recurse: true
-  with_items: "{{ containerd_insecure_registries }}"
-  when: containerd_insecure_registries is defined
-
-- name: containerd ｜ Write hosts.toml file
-  blockinfile:
-    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}/hosts.toml"
-    owner: "root"
-    mode: 0640
-    create: true
-    block: |
-      server = "{{ item.value }}"
-      [host."{{ item.value }}"]
-        capabilities = ["pull", "resolve", "push"]
-        skip_verify = true
-  with_items: "{{ containerd_insecure_registries }}"
-  when: containerd_insecure_registries is defined
+- name: Containerd | Configure containerd registries
+  when: containerd_registries_mirrors is defined
+  block:
+    - name: Containerd | Create registry directories
+      file:
+        path: "{{ containerd_cfg_dir }}/certs.d/{{ item.prefix }}"
+        state: directory
+        mode: 0755
+      loop: "{{ containerd_registries_mirrors }}"
+    - name: Containerd | Write hosts.toml file
+      template:
+        src: hosts.toml.j2
+        dest: "{{ containerd_cfg_dir }}/certs.d/{{ item.prefix }}/hosts.toml"
+        mode: 0640
+      loop: "{{ containerd_registries_mirrors }}"
 
 # you can sometimes end up in a state where everything is installed
 # but containerd was not started / enabled
-- name: containerd | Flush handlers
+- name: Containerd | Flush handlers
   meta: flush_handlers
 
-- name: containerd | Ensure containerd is started and enabled
-  service:
+- name: Containerd | Ensure containerd is started and enabled
+  systemd:
     name: containerd
     daemon_reload: yes
     enabled: yes

--- a/roles/container-engine/containerd/tasks/main.yml
+++ b/roles/container-engine/containerd/tasks/main.yml
@@ -3,7 +3,7 @@
   fail:
     msg: "{{ ansible_distribution }} is not supported by containerd."
   when:
-    - ansible_distribution not in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Fedora", "AlmaLinux", "Rocky", "Amazon", "Flatcar", "Flatcar Container Linux by Kinvolk", "Suse", "openSUSE Leap", "openSUSE Tumbleweed"]
+    - ansible_distribution not in ["CentOS", "OracleLinux", "RedHat", "Ubuntu", "Debian", "Fedora", "AlmaLinux", "Rocky", "Amazon", "Flatcar", "Flatcar Container Linux by Kinvolk", "Suse", "openSUSE Leap", "openSUSE Tumbleweed", "Kylin Linux Advanced Server", "UnionTech", "openEuler"]
 
 - name: containerd | Remove any package manager controlled containerd package
   package:
@@ -45,7 +45,9 @@
   file:
     path: "/usr/bin/{{ item }}"
     state: absent
-  when: containerd_bin_dir != "/usr/bin"
+  when:
+    - containerd_bin_dir != "/usr/bin"
+    - not (is_ostree or (ansible_distribution == "Flatcar Container Linux by Kinvolk") or (ansible_distribution == "Flatcar"))
   ignore_errors: true  # noqa ignore-errors
   with_items:
     - containerd
@@ -82,6 +84,25 @@
   notify: restart containerd
   when: http_proxy is defined or https_proxy is defined
 
+- name: containerd | Generate default base_runtime_spec
+  register: ctr_oci_spec
+  command: "{{ containerd_bin_dir }}/ctr oci spec"
+  check_mode: false
+  changed_when: false
+
+- name: containerd | Store generated default base_runtime_spec
+  set_fact:
+    containerd_default_base_runtime_spec: "{{ ctr_oci_spec.stdout | from_json }}"
+
+- name: containerd | Write base_runtime_specs
+  copy:
+    content: "{{ item.value }}"
+    dest: "{{ containerd_cfg_dir }}/{{ item.key }}"
+    owner: "root"
+    mode: 0644
+  with_dict: "{{ containerd_base_runtime_specs | default({}) }}"
+  notify: restart containerd
+
 - name: containerd | Copy containerd config file
   template:
     src: config.toml.j2
@@ -89,6 +110,29 @@
     owner: "root"
     mode: 0640
   notify: restart containerd
+
+- name: containerd ｜ Create registry directories
+  file:
+    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}"
+    state: directory
+    mode: 0755
+    recurse: true
+  with_items: "{{ containerd_insecure_registries }}"
+  when: containerd_insecure_registries is defined
+
+- name: containerd ｜ Write hosts.toml file
+  blockinfile:
+    path: "{{ containerd_cfg_dir }}/certs.d/{{ item.key }}/hosts.toml"
+    owner: "root"
+    mode: 0640
+    create: true
+    block: |
+      server = "{{ item.value }}"
+      [host."{{ item.value }}"]
+        capabilities = ["pull", "resolve", "push"]
+        skip_verify = true
+  with_items: "{{ containerd_insecure_registries }}"
+  when: containerd_insecure_registries is defined
 
 # you can sometimes end up in a state where everything is installed
 # but containerd was not started / enabled
@@ -98,5 +142,6 @@
 - name: containerd | Ensure containerd is started and enabled
   service:
     name: containerd
+    daemon_reload: yes
     enabled: yes
     state: started

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -18,23 +18,21 @@ oom_score = {{ containerd_oom_score }}
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
+    enable_unprivileged_ports = {{ containerd_enable_unprivileged_ports | default(false) | lower }}
+    enable_unprivileged_icmp = {{ containerd_enable_unprivileged_icmp | default(false) | lower }}
     [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "{{ containerd_default_runtime | default('runc') }}"
       snapshotter = "{{ containerd_snapshotter | default('overlayfs') }}"
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ containerd_runc_runtime.name }}]
-          runtime_type = "{{ containerd_runc_runtime.type }}"
-          runtime_engine = "{{ containerd_runc_runtime.engine}}"
-          runtime_root = "{{ containerd_runc_runtime.root }}"
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ containerd_runc_runtime.name }}.options]
-{% for key, value in containerd_runc_runtime.options.items() %}
-            {{ key }} = {{ value }}
-{% endfor %}
-{% for runtime in containerd_additional_runtimes %}
+{% for runtime in [containerd_runc_runtime] + containerd_additional_runtimes %}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ runtime.name }}]
           runtime_type = "{{ runtime.type }}"
           runtime_engine = "{{ runtime.engine }}"
           runtime_root = "{{ runtime.root }}"
+{% if runtime.base_runtime_spec is defined %}
+          base_runtime_spec = "{{ containerd_cfg_dir }}/{{ runtime.base_runtime_spec }}"
+{% endif %}
+
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{ runtime.name }}.options]
 {% for key, value in runtime.options.items() %}
             {{ key }} = {{ value }}
@@ -49,19 +47,22 @@ oom_score = {{ containerd_oom_score }}
           runtime_type = "io.containerd.runsc.v1"
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
-{% if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 %}
+{% if containerd_use_config_path is defined and containerd_use_config_path|bool %}
       config_path = "{{ containerd_cfg_dir }}/certs.d"
-{% endif %}
+{% else %}
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-{% for registry, addr in containerd_registries.items() %}
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
-          endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
+{% set insecure_registries_addr = [] %}
+{% for registry in containerd_registries_mirrors %}
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry.prefix }}"]
+{% set endpoint = [] %}
+{% for mirror in registry.mirrors %}
+{% if endpoint.append(mirror.host) %}{% endif %}
+{% if mirror.skip_verify is defined and mirror.skip_verify|bool %}{% if insecure_registries_addr.append(mirror.host | urlsplit('netloc')) %}{% endif %}{% endif %}
 {% endfor %}
-{% if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 %}
-{% for registry, addr in containerd_insecure_registries.items() %}
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
-          endpoint = ["{{ ([ addr ] | flatten ) | join('","') }}"]
-        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry }}".tls]
+          endpoint = ["{{ ( endpoint | unique ) | join('","') }}"]
+{% endfor %}
+{% for addr in insecure_registries_addr | unique %}
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ addr }}".tls]
           insecure_skip_verify = true
 {% endfor %}
 {% endif %}
@@ -76,6 +77,11 @@ oom_score = {{ containerd_oom_score }}
 {% endif %}
 {% endif %}
 {% endfor %}
+
+{% if nri_enabled and containerd_version is version('1.7.0', '>=') %}
+  [plugins."io.containerd.nri.v1.nri"]
+    disable = false
+{% endif %}
 
 {% if containerd_extra_args is defined %}
 {{ containerd_extra_args }}

--- a/roles/container-engine/containerd/templates/config.toml.j2
+++ b/roles/container-engine/containerd/templates/config.toml.j2
@@ -49,6 +49,9 @@ oom_score = {{ containerd_oom_score }}
           runtime_type = "io.containerd.runsc.v1"
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".registry]
+{% if containerd_insecure_registries is defined and containerd_insecure_registries|length>0 %}
+      config_path = "{{ containerd_cfg_dir }}/certs.d"
+{% endif %}
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
 {% for registry, addr in containerd_registries.items() %}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]

--- a/roles/container-engine/containerd/templates/hosts.toml.j2
+++ b/roles/container-engine/containerd/templates/hosts.toml.j2
@@ -1,0 +1,8 @@
+server = "https://{{ item.prefix }}"
+{% for mirror in item.mirrors %}
+[host."{{ mirror.host }}"]
+  capabilities = ["{{ ([ mirror.capabilities ] | flatten ) | join('","') }}"]
+{% if mirror.skip_verify is defined %}
+  skip_verify = {{ mirror.skip_verify | default('false') | string | lower }}
+{% endif %}
+{% endfor %}

--- a/roles/kubespray-defaults/defaults/main.yaml
+++ b/roles/kubespray-defaults/defaults/main.yaml
@@ -259,6 +259,10 @@ deploy_container_engine: "{{ inventory_hostname in groups['k8s_cluster'] or etcd
 # Container for runtime
 container_manager: containerd
 
+# Enable Node Resource Interface in containerd or CRI-O. Requires crio_version >= v1.26.0
+# or containerd_version >= 1.7.0.
+nri_enabled: false
+
 # Enable Kata Containers as additional container runtime
 # When enabled, it requires `container_manager` different than Docker
 kata_containers_enabled: false


### PR DESCRIPTION
This PR backports some containerd configurations from Kubespray version 2.23 so we are able to use registry mirrors.

https://github.com/kubernetes-sigs/kubespray/tree/release-2.23/roles/container-engine/containerd

This was rolled out to alpha-app-worker01 and can be tested like so:

```
sudo crictl pull docker-proxy.image-registry.powerapp.cloud/grafana/grafana:9.1.4
```